### PR TITLE
Update for guzzle 6 middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": ">=4.0,<6.0"
+        "guzzlehttp/guzzle": "~6.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.*"

--- a/src/GuzzleRecorder.php
+++ b/src/GuzzleRecorder.php
@@ -1,13 +1,9 @@
 <?php namespace Gsaulmon\GuzzleRecorder;
 
-use GuzzleHttp\Event\BeforeEvent;
-use GuzzleHttp\Event\CompleteEvent;
-use GuzzleHttp\Event\RequestEvents;
-use GuzzleHttp\Event\SubscriberInterface;
-use GuzzleHttp\Message\MessageFactory;
-use GuzzleHttp\Message\Request;
+use GuzzleHttp\Psr7;
+use Psr\Http\Message\RequestInterface;
 
-class GuzzleRecorder implements SubscriberInterface
+class GuzzleRecorder
 {
     private $path;
     private $include_cookies = true;
@@ -42,44 +38,41 @@ class GuzzleRecorder implements SubscriberInterface
         return $this;
     }
 
-    public function getEvents()
-    {
-        return [
-            'before' => array('onBefore', RequestEvents::LATE),
-            'complete' => array('onComplete'),
-        ];
+
+    public function record() {
+        return function(callable $handler) {
+            return function(RequestInterface $request, array $options) use ($handler) {
+
+                if (file_exists($this->getFullFilePath($request))) {
+                    $responseData = file_get_contents($this->getFullFilePath($request));
+
+                    $fakeResponse = Psr7\parse_response($responseData);
+
+                    return $handler($request, $options)->resolve($fakeResponse);
+                } else {
+                    return $handler($request, $options)->then(function(\Psr\Http\Message\ResponseInterface $response) use ($request) {
+
+                        if (!file_exists($this->getPath($request))) {
+                            mkdir($this->getPath($request), 0777, true);
+                        }
+
+                        file_put_contents($this->getFullFilePath($request), (string)$response);
+                        return $response;
+                    });
+                }
+
+
+            };
+        };
     }
 
-    public function onBefore(BeforeEvent $event)
+    protected function getPath(RequestInterface $request)
     {
-        $request = $event->getRequest();
+        $path = $this->path . DIRECTORY_SEPARATOR . strtolower($request->getMethod()) . DIRECTORY_SEPARATOR . $request->getUri()->getHost() . DIRECTORY_SEPARATOR;
 
-        if (file_exists($this->getFullFilePath($request))) {
-            $responsedata = file_get_contents($this->getFullFilePath($request));
-            $mf = new MessageFactory();
-            $event->intercept($mf->fromMessage($responsedata));
-        }
-    }
+        $rpath = $request->getUri()->getPath();
 
-    public function onComplete(CompleteEvent $event)
-    {
-        $request = $event->getRequest();
-
-        if (!file_exists($this->getPath($request))) {
-            mkdir($this->getPath($request), 0777, true);
-        }
-
-        $response = $event->getResponse();
-
-        file_put_contents($this->getFullFilePath($request), (string)$response);
-    }
-
-    protected function getPath(Request $request)
-    {
-        $path = $this->path . DIRECTORY_SEPARATOR . strtolower($request->getMethod()) . DIRECTORY_SEPARATOR . $request->getHost() . DIRECTORY_SEPARATOR;
-
-        if ($request->getPath() !== '/') {
-            $rpath = $request->getPath();
+        if ($rpath && $rpath !== '/') {
             $rpath = (substr($rpath, 0, 1) === '/') ? substr($rpath, 1) : $rpath;
             $rpath = (substr($rpath, -1, 1) === '/') ? substr($rpath, 0, -1) : $rpath;
 
@@ -89,9 +82,10 @@ class GuzzleRecorder implements SubscriberInterface
         return $path;
     }
 
-    protected function getFileName(Request $request)
+    protected function getFileName(RequestInterface $request)
     {
-        $result = trim($request->getMethod() . ' ' . $request->getResource())
+
+        $result = trim($request->getMethod() . ' ' . $request->getRequestTarget())
             . ' HTTP/' . $request->getProtocolVersion();
         foreach ($request->getHeaders() as $name => $values) {
             if (array_key_exists(strtoupper($name), $this->ignored_headers)) {
@@ -104,7 +98,7 @@ class GuzzleRecorder implements SubscriberInterface
         return md5((string)$request) . ".txt";
     }
 
-    protected function getFullFilePath(Request $request)
+    protected function getFullFilePath(RequestInterface $request)
     {
         return $this->getPath($request) . $this->getFileName($request);
     }

--- a/src/GuzzleRecorder.php
+++ b/src/GuzzleRecorder.php
@@ -104,19 +104,19 @@ class GuzzleRecorder
         return $response->then(
             function ($value) use ($request, $options) {
                 // record the response
-                $this->recordResponse($request, $value);
+                $this->record($request, $value);
 
                 return $value;
             },
             function ($reason) use ($request, $options) {
                 // record the response
-                $this->recordResponse($request, $reason);
+                $this->record($request, $reason);
 
                 return $reason;
         });
     }
 
-    public function recordResponse($response, $request)
+    public function record($request, $response)
     {
         $this->history[] = $response;
 

--- a/tests/GuzzleRecorderTest.php
+++ b/tests/GuzzleRecorderTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
 use Gsaulmon\GuzzleRecorder\GuzzleRecorder;
 
 class GuzzleRecorderTest extends PHPUnit_Framework_TestCase
@@ -16,8 +16,7 @@ class GuzzleRecorderTest extends PHPUnit_Framework_TestCase
     {
         $this->recorder = new GuzzleRecorder(__DIR__ . '/responses');
 
-        $stack = HandlerStack::create();
-        $stack->push($this->recorder->record());
+        $stack = HandlerStack::create($this->recorder);
 
         $this->client = new GuzzleHttp\Client([
             'defaults' => [

--- a/tests/GuzzleRecorderTest.php
+++ b/tests/GuzzleRecorderTest.php
@@ -1,28 +1,32 @@
 <?php
 
-use \Gsaulmon\GuzzleRecorder\GuzzleRecorder;
-use GuzzleHttp\Event\BeforeEvent;
-use GuzzleHttp\Message\Request;
-use GuzzleHttp\Transaction;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\HandlerStack;
+use Gsaulmon\GuzzleRecorder\GuzzleRecorder;
 
 class GuzzleRecorderTest extends PHPUnit_Framework_TestCase
 {
     /** @var GuzzleHttp\Client $client */
     private $client = null;
+
+    /** @var GuzzleRecorder $recorder */
     private $recorder = null;
 
     public function setup()
     {
+        $this->recorder = new GuzzleRecorder(__DIR__ . '/responses');
+
+        $stack = HandlerStack::create();
+        $stack->push($this->recorder->record());
+
         $this->client = new GuzzleHttp\Client([
             'defaults' => [
                 'headers' => [
                     'User-Agent' => 'GuzzleRecorder'
                 ]
-            ]
+            ],
+            'handler' => $stack
         ]);
-
-        $this->recorder = new GuzzleRecorder(__DIR__ . '/responses');
-        $this->client->getEmitter()->attach($this->recorder);
     }
 
     /** @test */


### PR DESCRIPTION
No backward compatibility was attempted.

new usage:

```
$history = [];

$watcher = new GuzzleRecorder(__DIR__ . '/Fixtures/Http', $history);
$stack = HandlerStack::create($watcher);

$client = new GuzzleHttp\Client(['handler' => $stack]);

$response = $this->client->get('https://google.com');
```
